### PR TITLE
provide keyboard shortcut to render and display the UML diagram

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -74,7 +74,7 @@
   (shell-command (concat plantuml-run-command " " buffer-file-name)))
 
 (defun plantuml-display-image()
-  "Display the render image"
+  "Display the rendered image"
   (interactive)
   (let ((plantuml-file (concat (file-name-sans-extension buffer-file-name) ".png")))
     (if (not (buffer-live-p (get-buffer (file-name-nondirectory plantuml-file))))


### PR DESCRIPTION
This pull request adds a keyboard shortcut (C-c C-c/plantuml-run-and-display) to run plantuml on the current buffer and to display the resulting .png file.
