### PR TITLE
Autoload plantuml-mode for '.(plantuml|puml)' ext.

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -263,5 +263,9 @@ Shortcuts             Command Name
   (setq comment-start "'")
   (run-mode-hooks 'plantuml-mode-hook))
 
+;;;###autoload
+(progn
+  (add-to-list 'auto-mode-alist '("\\.(plantuml|puml)\\'" . plantuml-mode)))
+
 (provide 'plantuml-mode)
 ;;; plantuml-mode ends here


### PR DESCRIPTION
So I don't have to manually initiate plantuml mode every time I open these files.